### PR TITLE
Ensure REX job exits zero for successful scans

### DIFF
--- a/app/views/foreman_cve_scanner/job_templates/run_cve_scanner.erb
+++ b/app/views/foreman_cve_scanner/job_templates/run_cve_scanner.erb
@@ -54,7 +54,7 @@ scanners = {
 
 if scanner == 'trivy'
     cmd = "#{scanners[:trivy][target]} #{path}"
-    options += " --scanners vuln --quiet --format json"
+    options += " --exit-code 0 --scanners vuln --quiet --format json"
 elsif scanner == 'grype'
     cmd = "#{scanners[:grype][target]}:#{path}"
     options += " --quiet --quiet --output json"


### PR DESCRIPTION
If you run a scan from Foreman Web UI, the REX job should report "success" if the job ran successfully.