### PR TITLE
Add UI

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -1,0 +1,22 @@
+name: JavaScript Testing
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - 'webpack/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/js_tests.yml'
+
+concurrency:
+  group: ${{ github.ref_name }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: JavaScript
+    uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@v0
+    with:
+      plugin: foreman_cve_scanner

--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -1,12 +1,10 @@
 ---
-name: Ruby Testing
-
-on:
-  pull_request:
+name: Ruby Tests
+"on":
   push:
     branches:
-      - 'main'
-      - '*-stable'
+      - main
+  pull_request:
 
 concurrency:
   group: ${{ github.ref_name }}-${{ github.workflow }}
@@ -14,12 +12,14 @@ concurrency:
 
 jobs:
   rubocop:
-    name: Rubocop
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+      command: bundle exec rubocop --parallel
 
-  test_ruby:
+  test:
     name: Ruby
     needs: rubocop
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: foreman_cve_scanner
+      matrix_exclude: '[{"ruby": "3.0", "node": "14"}]'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,51 +1,14 @@
-require:
-  - rubocop-performance
-  - rubocop-rails
-  - rubocop-minitest
-
-AllCops:
-  TargetRubyVersion: 2.7
-  TargetRailsVersion: 6.1
-  Exclude:
-    - 'node_modules/**/*'
-    - 'vendor/**/*'
+---
+inherit_gem:
+  theforeman-rubocop:
+    - strictest.yml
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
   IndentationWidth: 2
 
-Layout/EmptyLineAfterGuardClause:
+Gemspec/RequiredRubyVersion:
   Enabled: false
-
-Layout/LineLength:
-  Enabled: 120
-
-Metrics/ClassLength:
-  Max: 200
 
 Metrics/MethodLength:
-  Max: 20
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Metrics/PerceivedComplexity:
-  Max: 10
-
-Rails:
-  Enabled: true
-
-Style/Alias:
-  EnforcedStyle: prefer_alias_method
-
-# Don't enforce documentation
-Style/Documentation:
-  Enabled: false
-
-# Don't enforce frozen string literals
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-# Support both ruby19 and hash_rockets
-Style/HashSyntax:
-  Enabled: false
+  Max: 15

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -1,13 +1,27 @@
 # ForemanCveScanner
 
-Plugin to 
-1. install trivy/grype CVE scanners on a host using a Foreman Remote Execution (REX) job
-2. run a CVE scan using a REX job, collect the output and generate a Config Report
-   
-   ![image](https://github.com/ATIX-AG/foreman_cve_scanner/assets/25485845/85e3b676-7d90-41e5-bea5-7e0b5f4a685c)
+Version: 0.5.0
 
+Plugin to:
+1. install Trivy/Grype on a host using Foreman Remote Execution (REX)
+2. run CVE scans via REX and parse the results
+3. store scan history per host in a dedicated table
+4. expose scan data via API
+5. show CVE findings in the Host details UI
+6. show summary status in the Hosts list
 
-*Introdction here*
+![image](https://github.com/ATIX-AG/foreman_cve_scanner/assets/25485845/85e3b676-7d90-41e5-bea5-7e0b5f4a685c)
+
+## Features
+
+- REX job templates for installing and running CVE scans
+- JSON output parsing with robust handling of chunked stdout
+- Per-host scan history with totals and severity counts
+- API endpoints for scan history and latest scan
+- Host Details card with findings and modal view
+- Host Details tab “CVE scans” for full history
+- Hosts overview list column “CVE” with quick summary and modal
+- Integrated in the Host Status
 
 ## Installation
 
@@ -16,19 +30,18 @@ for how to install Foreman plugins
 
 ## Usage
 
-- Run the REX job to install trivy and/or grype
+- Run the REX job to install Trivy and/or Grype
 - Run the REX job to scan a host
-- Go to the Config Report page for a host to view the scan report
+- You can configure recurring CVE scans via `Monitor -> Jobs`
+- View results in:
+  - Hosts overview list column “CVE” (use 'Manage Columns' to enable)
+  - Host Details card and modal
+  - Host Details tab “CVE scans”
 
 ## TODO
 
-- Better possiblities to filter the Config Report (maybe an extension to ConfigReport in Foreman)
-- Have a scheduled REX Job to scan the hosts
-- Make it visible on the Host Details page or on Foreman directly, if a high priority CVE on a host occurs
-- Export a CVE scan
-- Deliver trivy / grype via Katello
-- More tests
-- API
+- Export scan results
+- Deliver Trivy/Grype via Katello
 
 ## Contributing
 
@@ -50,4 +63,3 @@ GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'bundler/setup'
 rescue LoadError

--- a/app/controllers/api/v2/cve_scans_controller.rb
+++ b/app/controllers/api/v2/cve_scans_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    # API controller for CVE scans per host.
+    class CveScansController < V2::BaseController
+      before_action :find_host
+
+      def resource_class
+        ::ForemanCveScanner::CveScan
+      end
+
+      api :GET, '/hosts/:host_id/cve_scans', N_('List CVE scans for a host')
+      description N_('Returns paginated CVE scan summaries for a host.')
+      param :host_id, :identifier, required: true
+      param :page, :number, desc: N_('Page number, starting at 1')
+      param :per_page, :number, desc: N_('Number of results per page')
+      def index
+        @cve_scans = cve_scans_index_scope.paginate(paginate_options)
+      end
+
+      api :GET, '/hosts/:host_id/cve_scans/latest', N_('Get latest CVE scan for a host')
+      description N_('Returns the most recent CVE scan for a host.')
+      param :host_id, :identifier, required: true
+      def latest
+        @cve_scan = cve_scans_index_scope.first
+        head :no_content if @cve_scan.nil?
+      end
+
+      api :GET, '/hosts/:host_id/cve_scans/:id', N_('Show CVE scan for a host')
+      description N_('Returns a specific CVE scan by id for a host.')
+      param :host_id, :identifier, required: true
+      param :id, :identifier, required: true
+      def show
+        @cve_scan = resource_class.for_host(@host.id).find(params[:id])
+      end
+
+      api :DELETE, '/hosts/:host_id/cve_scans/:id', N_('Delete a CVE scan')
+      description N_('Deletes a specific CVE scan by id for a host.')
+      param :host_id, :identifier, required: true
+      param :id, :identifier, required: true
+      def destroy
+        @cve_scan = resource_class.for_host(@host.id).find(params[:id])
+        process_response @cve_scan.destroy
+      end
+
+      private
+
+      def cve_scans_index_scope
+        scope = resource_class.for_host(@host.id).recent_first
+        return scope unless respond_to?(:resource_scope_for_index, true)
+        return scope unless scope.respond_to?(:search_for)
+
+        resource_scope_for_index(scope)
+      end
+
+      def find_host
+        scope = ::Host::Base.authorized(:view_hosts)
+        @host = scope.find_by(name: params[:host_id]) || scope.find_by(id: params[:host_id])
+        return if @host.present?
+
+        not_found
+      end
+    end
+  end
+end

--- a/app/lib/actions/foreman_cve_scanner/cve_scanner_job.rb
+++ b/app/lib/actions/foreman_cve_scanner/cve_scanner_job.rb
@@ -2,6 +2,7 @@
 
 module Actions
   module ForemanCveScanner
+    # Dynflow action that parses a CVE scan job output and stores the results.
     class CveScannerJob < Actions::EntryAction
       def self.subscribe
         Actions::RemoteExecution::RunHostJob
@@ -15,16 +16,9 @@ module Actions
 
       def finalize(*_args)
         host = Host.find(input[:host_id])
-        return if host.blank?
 
-        report = {
-          'host' => host.name,
-          'logs' => [],
-          'scan' => format_output(task.main_action.continuous_output.humanize),
-          'reported_at' => Time.now.utc.to_s,
-          'reporter' => 'cve_scan'
-        }
-        ConfigReportImporter.import(report)
+        ::ForemanCveScanner::ScanImporter.new(task.main_action.continuous_output)
+                                         .import_for_host!(host)
       end
 
       private
@@ -33,15 +27,6 @@ module Actions
         RemoteExecutionFeature.where(job_template_id: job_invocation.pattern_template_invocations
                                                                     .first
                                                                     .template_id, label: feature).any?
-      end
-
-      def format_output(job_output)
-        output = job_output.each_line(chomp: true)
-                           .drop_while { |l| !l.start_with? '===START' }.drop(1)
-                           .take_while { |l| !l.start_with? '===END' }
-                           .reject(&:empty?)
-                           .join('')
-        JSON.parse(output)
       end
     end
   end

--- a/app/models/concerns/foreman_cve_scanner/host_extensions.rb
+++ b/app/models/concerns/foreman_cve_scanner/host_extensions.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module ForemanCveScanner
+  # Adds CVE scan associations to hosts.
+  module HostExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :cve_scans,
+        class_name: 'ForemanCveScanner::CveScan',
+        foreign_key: :host_id,
+        dependent: :destroy,
+        inverse_of: :host
+    end
+  end
+end

--- a/app/models/foreman_cve_scanner/cve_scan.rb
+++ b/app/models/foreman_cve_scanner/cve_scan.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ForemanCveScanner
+  # Stores a single CVE scan result for a host.
+  class CveScan < ApplicationRecord
+    self.table_name = 'foreman_cve_scanner_cve_scans'
+
+    belongs_to :host, class_name: '::Host::Managed'
+
+    validates :host_id, :scanner, :raw, :summary, :findings, presence: true
+
+    scope :for_host, ->(host_id) { where(host_id: host_id) }
+    scope :recent_first, -> { order(created_at: :desc, id: :desc) }
+  end
+end

--- a/app/models/host_status/cve_status.rb
+++ b/app/models/host_status/cve_status.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module HostStatus
+  # Host status entry reflecting latest CVE scan severities.
+  class CveStatus < Status
+    CVE_SCANNER_STATUS_NONE = 0
+    CVE_SCANNER_STATUS_LOW = 1
+    CVE_SCANNER_STATUS_MEDIUM = 2
+    CVE_SCANNER_STATUS_CRITICAL_HIGH = 3
+
+    def self.status_name
+      N_('CVE')
+    end
+
+    def to_label(_options = {})
+      case latest_scan_severity
+      when :critical_high
+        N_('Critical or high CVEs')
+      when :medium
+        N_('Medium CVEs')
+      when :low
+        N_('Low CVEs')
+      when :none
+        N_('No CVE scans')
+      else
+        N_('No CVEs')
+      end
+    end
+
+    def to_global(_options = {})
+      case latest_scan_severity
+      when :critical_high
+        HostStatus::Global::ERROR
+      when :medium, :none
+        HostStatus::Global::WARN
+      else
+        HostStatus::Global::OK
+      end
+    end
+
+    def to_status(_options = {})
+      case latest_scan_severity
+      when :critical_high
+        CVE_SCANNER_STATUS_CRITICAL_HIGH
+      when :medium
+        CVE_SCANNER_STATUS_MEDIUM
+      when :low
+        CVE_SCANNER_STATUS_LOW
+      else
+        CVE_SCANNER_STATUS_NONE
+      end
+    end
+
+    private
+
+    def latest_scan
+      @latest_scan ||= ::ForemanCveScanner::CveScan.for_host(host_id).recent_first.first
+    end
+
+    def latest_scan_severity
+      scan = latest_scan
+      return :none if scan.nil?
+
+      return :critical_high if scan.critical.to_i.positive? || scan.high.to_i.positive?
+      return :medium if scan.medium.to_i.positive?
+      return :low if scan.low.to_i.positive?
+
+      :none
+    end
+  end
+end

--- a/app/services/foreman_cve_scanner/cve_report_scanner.rb
+++ b/app/services/foreman_cve_scanner/cve_report_scanner.rb
@@ -1,17 +1,10 @@
 # frozen_string_literal: true
 
 module ForemanCveScanner
-  # Scans ConfigReports after import for indicators of an CveScanner report and
-  # sets the origin of the report to 'CveScanner'
+  # Parses raw CVE scanner reports and produces unified logs/metrics.
+  # rubocop:disable Metrics/ClassLength
   class CveReportScanner
-    def self.add_reporter_data(_report, raw)
-      scanner = ForemanCveScanner::CveReportScanner.new(raw)
-      scanner.generate
-      raw['logs'] = scanner.logs
-      raw['status'] = scanner.status
-      raw['metrics'] = scanner.metrics
-      raw['report_status_calculator_options'] = { :metrics => %w[critical high medium low total] }
-    end
+    SEVERITY_ORDER = %w[CRITICAL HIGH MEDIUM LOW UNKNOWN].freeze
 
     def self.identify_origin(raw)
       'CveScanner' if cve_scanner_report?(raw)
@@ -37,9 +30,21 @@ module ForemanCveScanner
 
     attr_reader :logs, :status
 
+    def unified_vulnerabilities
+      @cve_report_data
+    end
+
+    def self.detect_scanner(scan_json)
+      return 'grype' if scan_json.is_a?(Hash) && scan_json.key?('matches')
+      return 'trivy' if scan_json.is_a?(Hash) && scan_json.key?('Results')
+
+      'unknown'
+    end
+
     def metrics
-      res = @status
-      res['total'] = @status.values.sum
+      known = %w[critical high medium low]
+      res = @status.slice(*known)
+      res['total'] = res.values.sum
       res
     end
 
@@ -47,34 +52,29 @@ module ForemanCveScanner
 
     def generate_log_from_unified(id, entry)
       {
-        'log': {
-          'level': consume_severity_level(entry['severity']),
-          'messages': {
-            message: "#{id}: #{entry['title']} # url: #{entry['url']}"
+        log: {
+          level: consume_severity_level(entry['severity']),
+          messages: {
+            message: "#{id}: #{entry['title']} # url: #{entry['url']}",
           },
           sources: {
-            source: "#{entry['name']} @ #{entry['version']}"
-          }
-        }
+            source: "#{entry['name']} @ #{entry['version']}",
+          },
+        },
       }.deep_stringify_keys
     end
 
     def consume_severity_level(severity)
+      severity = severity.to_s.strip.upcase
       @status[severity.downcase] = 0 unless @status.key?(severity.downcase)
       @status[severity.downcase] += 1
 
-      case severity
-      when 'CRITICAL'
-        'err'
-      when 'HIGH'
-        'warning'
-      when 'MEDIUM'
-        'info'
-      when 'LOW'
-        'debug'
-      else
-        'info'
-      end
+      {
+        'CRITICAL' => 'err',
+        'HIGH' => 'warning',
+        'MEDIUM' => 'info',
+        'LOW' => 'debug',
+      }.fetch(severity, 'info')
     end
 
     def generate_grype_entry(entry)
@@ -83,7 +83,7 @@ module ForemanCveScanner
         'version' => entry['artifact']['version'],
         'title' => entry['vulnerability']['description'].gsub(/[\[\]"\\]/, ''),
         'severity' => entry['vulnerability']['severity'],
-        'url' => entry['vulnerability']['dataSource']
+        'url' => entry['vulnerability']['dataSource'],
       }
     end
 
@@ -95,13 +95,13 @@ module ForemanCveScanner
         'severity' => entry['Severity'],
         'url' => entry['PrimaryURL'],
         'status' => entry['Status'],
-        'fixed' => entry['FixedVersion'] || 'open'
+        'fixed' => entry['FixedVersion'] || 'open',
       }
       unified['published'] = entry['PublishedDate'] if entry.key?('PublishedDate')
       unified
     end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def generate_unified_vuls
       raise ::Foreman::Exception, _('Invalid CVE scanner report') unless @raw_data.key?('scan')
 
@@ -114,6 +114,7 @@ module ForemanCveScanner
       elsif j.key?('Results') # Trivy
         j['Results'].each do |r|
           next unless r.key? 'Vulnerabilities'
+
           r['Vulnerabilities'].each do |vul|
             vuls[vul['VulnerabilityID']] = generate_trivy_entry(vul)
           end
@@ -125,6 +126,7 @@ module ForemanCveScanner
 
       vuls
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/services/foreman_cve_scanner/scan_importer.rb
+++ b/app/services/foreman_cve_scanner/scan_importer.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module ForemanCveScanner
+  # Import CVE scan results from REX job output and persist them.
+  class ScanImporter
+    def initialize(job_output)
+      @job_output = job_output
+    end
+
+    def import_for_host!(host)
+      scan_json = format_output(@job_output)
+      return nil if scan_json.nil?
+
+      scanner_name = ::ForemanCveScanner::CveReportScanner.detect_scanner(scan_json)
+      persist_scan!(host, scanner_name, scan_json)
+    end
+
+    private
+
+    def format_output(job_output)
+      output_source = normalize_job_output(job_output)
+      json_text = extract_json(output_source)
+      if json_text.blank? && output_source.to_s.strip.present?
+        Rails.logger.warn('CVE scan output did not contain markers or JSON content')
+      end
+      return nil if json_text.blank?
+
+      JSON.parse(json_text)
+    rescue JSON::ParserError => e
+      Rails.logger.error("CVE scan output parse failed: #{e}")
+      nil
+    end
+
+    def extract_json(output_source)
+      output = output_source.to_s.each_line(chomp: true)
+                            .drop_while { |line| !line.start_with?('===START') }
+                            .drop(1)
+                            .take_while { |line| !line.start_with?('===END') }
+                            .reject(&:empty?)
+                            .join
+      output.strip
+    end
+
+    def normalize_job_output(job_output)
+      return concat_proxy_output(job_output) if job_output.is_a?(Hash) && job_output.key?('proxy_output')
+
+      output_source = job_output
+      output_source = job_output.humanize if job_output.respond_to?(:humanize) && !job_output.is_a?(String)
+      output_source.to_s
+    end
+
+    def concat_proxy_output(job_output)
+      result = job_output.dig('proxy_output', 'result') || []
+      result.filter_map { |item| item['output'] if item['output_type'] == 'stdout' }.join
+    end
+
+    def persist_scan!(host, scanner_name, scan_json)
+      scanner = ::ForemanCveScanner::CveReportScanner.new('scan' => scan_json)
+      scanner.generate
+
+      metrics = scanner.metrics
+      scan = ::ForemanCveScanner::CveScan.create!(
+        build_scan_attributes(host, scanner_name, scan_json, metrics, scanner)
+      )
+      refresh_host_status(host)
+      scan
+    end
+
+    def refresh_host_status(host)
+      status = ::HostStatus::CveStatus.find_or_initialize_by(host: host)
+      status.refresh!
+    rescue StandardError => e
+      Rails.logger.error("CVE status refresh failed for host_id=#{host.id}: #{e}")
+    end
+
+    def worst_severity(metrics)
+      %w[critical high medium low].each do |severity|
+        return severity if metrics[severity].to_i.positive?
+      end
+      'none'
+    end
+
+    def build_scan_attributes(host, scanner_name, scan_json, metrics, scanner)
+      summary = metrics.merge('worst' => worst_severity(metrics))
+      {
+        host: host,
+        scanner: scanner_name,
+        raw: scan_json,
+        summary: summary,
+        findings: build_findings(scanner),
+        total: metrics['total'].to_i,
+        critical: metrics['critical'].to_i,
+        high: metrics['high'].to_i,
+        medium: metrics['medium'].to_i,
+        low: metrics['low'].to_i,
+      }
+    end
+
+    def build_findings(scanner)
+      scanner.unified_vulnerabilities.map do |id, entry|
+        entry.merge('id' => id)
+      end
+    end
+  end
+end

--- a/app/views/api/v2/cve_scans/base.json.rabl
+++ b/app/views/api/v2/cve_scans/base.json.rabl
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+object @cve_scan
+
+attributes :id, :host_id, :scanner, :created_at, :total, :critical, :high, :medium, :low, :summary

--- a/app/views/api/v2/cve_scans/index.json.rabl
+++ b/app/views/api/v2/cve_scans/index.json.rabl
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+collection @cve_scans
+
+extends 'api/v2/cve_scans/base'

--- a/app/views/api/v2/cve_scans/latest.json.rabl
+++ b/app/views/api/v2/cve_scans/latest.json.rabl
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+object @cve_scan
+
+extends 'api/v2/cve_scans/main'

--- a/app/views/api/v2/cve_scans/main.json.rabl
+++ b/app/views/api/v2/cve_scans/main.json.rabl
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+object @cve_scan
+
+extends 'api/v2/cve_scans/base'
+
+attributes :findings, :created_at, :updated_at

--- a/app/views/api/v2/cve_scans/show.json.rabl
+++ b/app/views/api/v2/cve_scans/show.json.rabl
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+object @cve_scan
+
+extends 'api/v2/cve_scans/main'

--- a/app/views/foreman_cve_scanner/job_templates/run_cve_scanner.erb
+++ b/app/views/foreman_cve_scanner/job_templates/run_cve_scanner.erb
@@ -13,6 +13,7 @@ template_inputs:
   options: "filesystem\r\ndocker"
   advanced: false
   value_type: plain
+  default: filesystem
   hidden_value: false
 - name: options
   required: false
@@ -25,6 +26,7 @@ template_inputs:
   input_type: user
   advanced: false
   value_type: plain
+  default: /
   hidden_value: false
 - name: scanner
   required: true
@@ -39,7 +41,7 @@ template_inputs:
 scanner = input('scanner')
 target = input('target').to_sym
 path = input('path')
-options = input('options')
+options = input('options').to_s
 
 scanners = {
     trivy: {
@@ -57,7 +59,7 @@ if scanner == 'trivy'
     options += " --exit-code 0 --scanners vuln --quiet --format json"
 elsif scanner == 'grype'
     cmd = "#{scanners[:grype][target]}:#{path}"
-    options += " --quiet --quiet --output json"
+    options += " --quiet --output json"
 end
 exec_command = "#{scanner} #{cmd} #{options}"
 -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  namespace :api, defaults: { format: 'json' } do
+    scope '(:apiv)', module: :v2,
+                     defaults: { apiv: 'v2' },
+                     apiv: /v1|v2/,
+                     constraints: ApiConstraints.new(version: 2, default: true) do
+      constraints(host_id: %r{[^/]+}) do
+        resources :hosts, only: [] do
+          resources :cve_scans, only: %i[index show] do
+            collection do
+              get :latest
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20260221000000_create_foreman_cve_scanner_cve_scans.rb
+++ b/db/migrate/20260221000000_create_foreman_cve_scanner_cve_scans.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Creates the CVE scans table for per-host scan history.
+class CreateForemanCveScannerCveScans < ActiveRecord::Migration[6.1]
+  def change
+    create_table :foreman_cve_scanner_cve_scans do |t|
+      t.references :host, null: false, foreign_key: true
+      t.string :scanner, null: false
+      t.jsonb :raw, null: false
+      t.jsonb :summary, null: false, default: {}
+      t.jsonb :findings, null: false, default: []
+      t.integer :total, null: false, default: 0
+      t.integer :critical, null: false, default: 0
+      t.integer :high, null: false, default: 0
+      t.integer :medium, null: false, default: 0
+      t.integer :low, null: false, default: 0
+      t.timestamps
+    end
+
+    add_index :foreman_cve_scanner_cve_scans, %i[host_id created_at]
+  end
+end

--- a/db/seeds.d/75_job_templates.rb
+++ b/db/seeds.d/75_job_templates.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+User.as_anonymous_admin do
+  JobTemplate.without_auditing do
+    template_glob = File.join(
+      ForemanCveScanner::Engine.root,
+      'app/views/foreman_cve_scanner/job_templates/**/*.erb'
+    )
+    Dir[template_glob].each do |template|
+      sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
+      template = JobTemplate.import_raw!(File.read(template), default: true, lock: true, update: sync)
+
+      template.organizations << Organization.unscoped.all if template&.organizations&.empty?
+      template.locations << Location.unscoped.all if template&.locations&.empty?
+    end
+  end
+end

--- a/foreman_cve_scanner.gemspec
+++ b/foreman_cve_scanner.gemspec
@@ -1,21 +1,20 @@
+# frozen_string_literal: true
+
 require File.expand_path('lib/foreman_cve_scanner/version', __dir__)
 require 'date'
 
-# rubocop:disable Rails/Date
 Gem::Specification.new do |s|
   s.name        = 'foreman_cve_scanner'
   s.version     = ForemanCveScanner::VERSION
-  s.date        = Date.today.to_s
   s.metadata    = { 'is_foreman_plugin' => 'true' }
   s.license     = 'GPL-3.0'
   s.authors     = ['Bernhard Suttner']
   s.email       = ['suttner@atix.de']
   s.homepage    = 'https://github.com/ATIX-AG/foreman_cve_scanner'
   s.summary     = 'Run CVE scan on host and collect report'
-  # also update locale/gemspec.rb
   s.description = 'Run CVE scan on host and collect report'
 
-  s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
+  s.files = Dir['{app,config,db,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md', 'package.json']
   s.test_files = Dir['test/**/*'] + Dir['webpack/**/__tests__/*.js']
 
   s.required_ruby_version = '>= 2.7', '< 4'
@@ -25,4 +24,3 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
 end
-# rubocop:enable Rails/Date

--- a/lib/foreman_cve_scanner.rb
+++ b/lib/foreman_cve_scanner.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require 'foreman_cve_scanner/engine'
 
-module ForemanPluginTemplate
+# Foreman CVE Scanner plugin namespace.
+module ForemanCveScanner
 end

--- a/lib/foreman_cve_scanner/engine.rb
+++ b/lib/foreman_cve_scanner/engine.rb
@@ -1,21 +1,43 @@
+# frozen_string_literal: true
+
 require 'foreman_remote_execution'
 
 module ForemanCveScanner
+  # Rails engine for the Foreman CVE Scanner plugin.
   class Engine < ::Rails::Engine
     engine_name 'foreman_cve_scanner'
 
-    initializer 'foreman_cve_scanner.register_plugin', :before => :finisher_hook do |app|
+    initializer 'foreman_cve_scanner.load_app_instance_data' do |app|
+      ForemanCveScanner::Engine.paths['db/migrate'].existent.each do |path|
+        app.config.paths['db/migrate'] << path
+      end
+    end
+
+    initializer 'foreman_cve_scanner.register_plugin', before: :finisher_hook do |app|
       app.reloader.to_prepare do
         Foreman::Plugin.register :foreman_cve_scanner do
           requires_foreman '>= 3.13'
-          register_report_scanner ForemanCveScanner::CveReportScanner
-          register_report_origin 'CveScanner', 'ConfigReport'
+          register_global_js_file 'fills'
+
+          apipie_documented_controllers ["#{ForemanCveScanner::Engine.root}/app/controllers/api/v2/*.rb"]
+
+          security_block :foreman_cve_scanner do
+            permission :view_cve_scans,
+              { 'api/v2/cve_scans': %i[index latest show destroy] },
+              resource_type: 'Host'
+          end
+
+          add_all_permissions_to_default_roles
         end
       end
     end
 
     # Include concerns in this config.to_prepare block
     config.to_prepare do
+      require_dependency 'foreman_cve_scanner/host_extensions'
+      Host::Managed.include ForemanCveScanner::HostExtensions
+      require_dependency 'host_status/cve_status'
+      HostStatus.status_registry.add(HostStatus::CveStatus)
       ForemanCveScanner::Engine.register_rex_features
     end
 

--- a/lib/foreman_cve_scanner/version.rb
+++ b/lib/foreman_cve_scanner/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ForemanCveScanner
-  VERSION = '0.0.3'.freeze
+  VERSION = '0.5.0'
 end

--- a/lib/tasks/foreman_cve_scanner_seeds.rake
+++ b/lib/tasks/foreman_cve_scanner_seeds.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :foreman_cve_scanner do
+  desc 'Seed Foreman CVE Scanner job templates'
+  task seed_job_templates: :environment do
+    require Rails.root.join('lib/seed_helper')
+    require 'foreman_remote_execution'
+    paths = Dir["#{ForemanCveScanner::Engine.root}/app/views/foreman_cve_scanner/job_templates/*.erb"]
+    SeedHelper.import_templates(paths, 'ForemanCveScanner')
+    puts "Seeded #{paths.size} Foreman CVE Scanner job templates"
+  end
+end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+begin
+  require 'rubocop/rake_task'
+
+  test_patterns = [
+    "#{ForemanCveScanner::Engine.root}/*.gemspec",
+    "#{ForemanCveScanner::Engine.root}/*.rb",
+    "#{ForemanCveScanner::Engine.root}/app/**/*.rb",
+    "#{ForemanCveScanner::Engine.root}/config/**/*.rb",
+    "#{ForemanCveScanner::Engine.root}/db/**/*.rb",
+    "#{ForemanCveScanner::Engine.root}/lib/**/*.rake",
+    "#{ForemanCveScanner::Engine.root}/lib/**/*.rb",
+    "#{ForemanCveScanner::Engine.root}/test/**/*.rb",
+  ]
+
+  namespace :foreman_cve_scanner do
+    desc 'Runs Rubocop style checker'
+    RuboCop::RakeTask.new(:rubocop) do |task|
+      task.patterns = test_patterns
+    end
+
+    desc 'Runs Rubocop style checker with xml output for Jenkins'
+    RuboCop::RakeTask.new('rubocop:jenkins') do |task|
+      task.patterns = test_patterns
+      task.requires = ['rubocop/formatter/checkstyle_formatter']
+      task.formatters = ['RuboCop::Formatter::CheckstyleFormatter']
+      task.options = ['--no-color', '--out', 'rubocop.xml']
+    end
+  end
+rescue LoadError
+  # 'Rubocop not loaded.'
+end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "foreman_cve_scanner",
+  "version": "0.5.0",
+  "description": "Run CVE scan on host and collect report",
+  "main": "webpack/index.js",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "lint": "tfm-lint --plugin -d /webpack",
+    "test": "tfm-test --plugin",
+    "create-react-component": "yo react-domain"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/ATIX-AG/foreman_cve_scanner.git"
+  },
+  "peerDependencies": {
+    "@theforeman/vendor": ">= 8.16.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.7.0",
+    "@theforeman/builder": "^15.0.0",
+    "@theforeman/eslint-plugin-foreman": "^15.0.0",
+    "@theforeman/find-foreman": "^15.0.0",
+    "@theforeman/vendor-dev": "^15.0.0",
+    "babel-eslint": ">= 10.0.3",
+    "eslint": "^6.7.2",
+    "eslint-plugin-react": ">= 7.27.1",
+    "eslint-plugin-react-hooks": ">= 4.3.0",
+    "eslint-plugin-spellcheck": ">= 0.0.17",
+    "prettier": "^1.19.1"
+  },
+  "keywords": [
+    "CVE",
+    "Trivy",
+    "Grype",
+    "security",
+    "Foreman"
+  ],
+  "author": "ATIX AG",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/ATIX-AG/foreman_cve_scanner/issues"
+  },
+  "homepage": "https://github.com/ATIX-AG/foreman_cve_scanner#readme"
+}

--- a/test/actions/foreman_cve_scanner/cve_scanner_job_test.rb
+++ b/test/actions/foreman_cve_scanner/cve_scanner_job_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module ForemanCveScanner
+  class CveScannerJobTest < ActiveSupport::TestCase
+    def setup
+      @host = FactoryBot.create(:host)
+    end
+
+    test 'format_output parses json between markers across proxy output entries' do
+      job_output = {
+        'proxy_output' => {
+          'result' => [
+            { 'output_type' => 'stdout', 'output' => "===START\n{\"key\":" },
+            { 'output_type' => 'stdout', 'output' => "1}\n===END\n" },
+          ],
+        },
+      }
+
+      importer = ForemanCveScanner::ScanImporter.new(job_output)
+      parsed = importer.send(:format_output, job_output)
+
+      assert_equal({ 'key' => 1 }, parsed)
+    end
+
+    test 'persist_scan! stores scan and metrics' do
+      scan_json = JSON.parse(
+        File.read(File.join(ForemanCveScanner::Engine.root, 'test/fixtures/trivy.json'))
+      )
+
+      importer = ForemanCveScanner::ScanImporter.new('')
+      scan = importer.send(:persist_scan!, @host, 'trivy', scan_json)
+
+      assert scan.persisted?
+      assert scan.total.positive?
+      assert_equal @host.id, scan.host_id
+    end
+
+    test 'import_for_host! creates scan from rex output' do
+      output = [
+        '===START',
+        File.read(File.join(ForemanCveScanner::Engine.root, 'test/fixtures/trivy.json')),
+        '===END',
+      ].join("\n")
+
+      importer = ForemanCveScanner::ScanImporter.new(output)
+      scan = importer.import_for_host!(@host)
+
+      assert scan.persisted?
+      assert_equal @host.id, scan.host_id
+    end
+  end
+end

--- a/test/controllers/api/v2/cve_scans_controller_test.rb
+++ b/test/controllers/api/v2/cve_scans_controller_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    class CveScansControllerTest < ActionController::TestCase
+      def setup
+        @host = FactoryBot.create(:host)
+        @scan_old = create_scan(created_at: 2.hours.ago, total: 1, low: 1)
+        @scan_new = create_scan(created_at: 1.hour.ago, total: 2, high: 2)
+      end
+
+      test 'index returns scans for host' do
+        get :index, params: { host_id: @host.id }
+        assert_response :success
+        body = ActiveSupport::JSON.decode(@response.body)
+        assert_not_nil body['results']
+        assert_equal 2, body['results'].size
+      end
+
+      test 'latest returns most recent scan' do
+        get :latest, params: { host_id: @host.id }
+        assert_response :success
+        body = ActiveSupport::JSON.decode(@response.body)
+        assert_equal @scan_new.id, body['id']
+      end
+
+      test 'show returns scan by id' do
+        get :show, params: { host_id: @host.id, id: @scan_old.id }
+        assert_response :success
+        body = ActiveSupport::JSON.decode(@response.body)
+        assert_equal @scan_old.id, body['id']
+      end
+
+      test 'index returns not found for unknown host' do
+        get :index, params: { host_id: 'does-not-exist' }
+        assert_response :not_found
+      end
+
+      test 'latest returns no content when no scans exist' do
+        ForemanCveScanner::CveScan.delete_all
+
+        get :latest, params: { host_id: @host.id }
+        assert_response :no_content
+      end
+
+      private
+
+      # rubocop:disable Metrics/MethodLength
+      def create_scan(options = {})
+        defaults = {
+          created_at: Time.now.utc,
+          total: 0,
+          critical: 0,
+          high: 0,
+          medium: 0,
+          low: 0,
+        }
+        options = defaults.merge(options)
+        ForemanCveScanner::CveScan.create!(
+          host: @host,
+          scanner: 'trivy',
+          created_at: options[:created_at],
+          raw: { 'dummy' => true },
+          summary: { 'worst' => 'low' },
+          findings: [{ 'id' => 'CVE-0000-0000' }],
+          total: options[:total],
+          critical: options[:critical],
+          high: options[:high],
+          medium: options[:medium],
+          low: options[:low]
+        )
+      end
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/test/models/host_status/cve_status_test.rb
+++ b/test/models/host_status/cve_status_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module HostStatus
+  class CveStatusTest < ActiveSupport::TestCase
+    def setup
+      @host = FactoryBot.create(:host)
+    end
+
+    test 'no scans returns warning status' do
+      status = @host.get_status(HostStatus::CveStatus)
+      assert_equal 'No CVE scans', status.to_label
+      assert_equal HostStatus::Global::WARN, status.to_global
+      assert_equal 0, status.to_status
+    end
+
+    test 'critical or high scan returns error status' do
+      create_scan(critical: 1, high: 0, medium: 0, low: 0)
+      status = @host.get_status(HostStatus::CveStatus)
+      assert_equal 'Critical or high CVEs', status.to_label
+      assert_equal HostStatus::Global::ERROR, status.to_global
+      assert_equal 3, status.to_status
+    end
+
+    test 'medium scan returns warn status' do
+      create_scan(critical: 0, high: 0, medium: 2, low: 0)
+      status = @host.get_status(HostStatus::CveStatus)
+      assert_equal 'Medium CVEs', status.to_label
+      assert_equal HostStatus::Global::WARN, status.to_global
+      assert_equal 2, status.to_status
+    end
+
+    test 'low scan returns ok status' do
+      create_scan(critical: 0, high: 0, medium: 0, low: 1)
+      status = @host.get_status(HostStatus::CveStatus)
+      assert_equal 'Low CVEs', status.to_label
+      assert_equal HostStatus::Global::OK, status.to_global
+      assert_equal 1, status.to_status
+    end
+
+    test 'status is registered in registry' do
+      assert_includes HostStatus.status_registry, HostStatus::CveStatus
+    end
+
+    private
+
+    def create_scan(critical:, high:, medium:, low:)
+      total = critical + high + medium + low
+      ForemanCveScanner::CveScan.create!(
+        host: @host,
+        scanner: 'trivy',
+        created_at: Time.now.utc,
+        raw: { 'dummy' => true },
+        summary: { 'worst' => 'low' },
+        findings: [{ 'id' => 'CVE-0000-0000' }],
+        total: total,
+        critical: critical,
+        high: high,
+        medium: medium,
+        low: low
+      )
+    end
+  end
+end

--- a/test/services/foreman_cve_scanner/cve_report_scanner_test.rb
+++ b/test/services/foreman_cve_scanner/cve_report_scanner_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_plugin_helper'
 
 module ForemanCveScanner
@@ -5,9 +7,9 @@ module ForemanCveScanner
     test 'should identify as cve scan' do
       raw = {
         'reporter' => 'cve_scan',
-        'scan' => JSON.parse(File.read(File.join(ForemanCveScanner::Engine.root, 'test/fixtures/grype.json')))
+        'scan' => JSON.parse(File.read(File.join(ForemanCveScanner::Engine.root, 'test/fixtures/grype.json'))),
       }
-      assert_equal ForemanCveScanner::CveReportScanner.identify_origin(raw), 'CveScanner'
+      assert_equal('CveScanner', ForemanCveScanner::CveReportScanner.identify_origin(raw))
     end
 
     test 'should raise an exception if invalid report' do
@@ -18,26 +20,52 @@ module ForemanCveScanner
 
     test 'trivy scan has valid data' do
       data = JSON.parse(File.read(File.join(ForemanCveScanner::Engine.root, 'test/fixtures/trivy.json')))
-      raw = {
-        'reporter' => 'cve_scan',
-        'scan' => data
-      }
-      ForemanCveScanner::CveReportScanner.add_reporter_data(nil, raw)
-      assert_equal raw['logs'].count, 10
-      assert_equal raw['logs'][0]['log']['level'], 'info'
-      assert_equal raw['logs'][0]['log']['messages']['message'], 'CVE-2020-12762: json-c, libfastjson: integer overflow and out-of-bounds write via a large JSON file # url: https://avd.aquasec.com/nvd/cve-2020-12762'
+      scanner = ForemanCveScanner::CveReportScanner.new('scan' => data)
+      scanner.generate
+      assert_equal(10, scanner.logs.count)
+      assert_equal('info', scanner.logs[0]['log']['level'])
+      expected_message = [
+        'CVE-2020-12762: json-c, libfastjson: integer overflow and out-of-',
+        'bounds write via a large JSON file # url: ',
+        'https://avd.aquasec.com/nvd/cve-2020-12762',
+      ].join
+      assert_equal scanner.logs[0]['log']['messages']['message'], expected_message
     end
 
     test 'grype scan has valid data' do
       data = JSON.parse(File.read(File.join(ForemanCveScanner::Engine.root, 'test/fixtures/grype.json')))
-      raw = {
-        'reporter' => 'cve_scan',
-        'scan' => data
+      scanner = ForemanCveScanner::CveReportScanner.new('scan' => data)
+      scanner.generate
+      assert_equal(18, scanner.logs.count)
+      first_severity = data.dig('matches', 0, 'vulnerability', 'severity')
+      expected_level = expected_level_for(first_severity)
+      assert_equal scanner.logs[0]['log']['level'], expected_level
+      expected_message = [
+        'CVE-2007-0086: The Apache HTTP Server, when accessed through a TCP ',
+        'connection with a large window size, allows remote attackers to cause ',
+        'a denial of service (network bandwidth consumption) via a Range header ',
+        'that specifies multiple copies of the same fragment. # url: ',
+        'https://nvd.nist.gov/vuln/detail/CVE-2007-0086',
+      ].join
+      assert_equal scanner.logs[0]['log']['messages']['message'], expected_message
+    end
+
+    test 'detect_scanner returns expected scanner names' do
+      assert_equal 'grype', ForemanCveScanner::CveReportScanner.detect_scanner('matches' => [])
+      assert_equal 'trivy', ForemanCveScanner::CveReportScanner.detect_scanner('Results' => [])
+      assert_equal 'unknown', ForemanCveScanner::CveReportScanner.detect_scanner('foo' => 'bar')
+    end
+
+    private
+
+    def expected_level_for(severity)
+      map = {
+        'CRITICAL' => 'err',
+        'HIGH' => 'warning',
+        'MEDIUM' => 'info',
+        'LOW' => 'debug',
       }
-      ForemanCveScanner::CveReportScanner.add_reporter_data(nil, raw)
-      assert_equal raw['logs'].count, 18
-      assert_equal raw['logs'][0]['log']['level'], 'info'
-      assert_equal raw['logs'][0]['log']['messages']['message'], 'CVE-2007-0086: The Apache HTTP Server, when accessed through a TCP connection with a large window size, allows remote attackers to cause a denial of service (network bandwidth consumption) via a Range header that specifies multiple copies of the same fragment. # url: https://nvd.nist.gov/vuln/detail/CVE-2007-0086'
+      map.fetch(severity.to_s.strip.upcase, 'info')
     end
   end
 end

--- a/test/services/foreman_cve_scanner/scan_importer_test.rb
+++ b/test/services/foreman_cve_scanner/scan_importer_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+module ForemanCveScanner
+  class ScanImporterTest < ActiveSupport::TestCase
+    def setup
+      @host = FactoryBot.create(:host)
+    end
+
+    test 'import_for_host! persists scan from trivy output' do
+      output = wrap_output(load_fixture('trivy.json'))
+      importer = ForemanCveScanner::ScanImporter.new(output)
+
+      count_before = ForemanCveScanner::CveScan.count
+      scan = importer.import_for_host!(@host)
+
+      assert_equal count_before + 1, ForemanCveScanner::CveScan.count
+      assert_not_nil scan
+      assert_equal @host.id, scan.host_id
+      assert_equal 'trivy', scan.scanner
+    end
+
+    test 'import_for_host! sets totals and findings for trivy output' do
+      output = wrap_output(load_fixture('trivy.json'))
+      importer = ForemanCveScanner::ScanImporter.new(output)
+
+      scan = importer.import_for_host!(@host)
+
+      assert_operator scan.total, :>, 0
+      assert_equal scan.total, scan.findings.count
+    end
+
+    test 'import_for_host! persists scan from proxy output' do
+      output = load_fixture('grype.json')
+      proxy_output = {
+        'proxy_output' => {
+          'result' => [
+            { 'output_type' => 'stdout', 'output' => "===START\n" },
+            { 'output_type' => 'stdout', 'output' => output },
+            { 'output_type' => 'stdout', 'output' => "\n===END\n" },
+          ],
+        },
+      }
+      importer = ForemanCveScanner::ScanImporter.new(proxy_output)
+
+      scan = importer.import_for_host!(@host)
+
+      assert_not_nil scan
+      assert_equal 'grype', scan.scanner
+      assert_operator scan.total, :>, 0
+    end
+
+    test 'import_for_host! returns nil when no json markers' do
+      importer = ForemanCveScanner::ScanImporter.new('no markers here')
+
+      scan = importer.import_for_host!(@host)
+
+      assert_nil scan
+    end
+
+    test 'import_for_host! returns nil when json is invalid' do
+      importer = ForemanCveScanner::ScanImporter.new("===START\n{bad\n===END")
+
+      scan = importer.import_for_host!(@host)
+
+      assert_nil scan
+    end
+
+    private
+
+    def load_fixture(name)
+      path = File.join(ForemanCveScanner::Engine.root, 'test/fixtures', name)
+      JSON.parse(File.read(path)).to_json
+    end
+
+    def wrap_output(json_text)
+      [
+        '===START',
+        json_text,
+        '===END',
+      ].join("\n")
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This calls the main test_helper in Foreman-core
 require 'test_helper'
 

--- a/webpack/components/CveDetailsCard.js
+++ b/webpack/components/CveDetailsCard.js
@@ -1,0 +1,258 @@
+/* eslint-disable import/no-unresolved */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Table, Tbody, Tr, Th, Thead, Td } from '@patternfly/react-table';
+import {
+  Text,
+  TextContent,
+  TextVariants,
+  Button,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Title,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
+import SkeletonLoader from 'foremanReact/components/common/SkeletonLoader';
+import { STATUS } from 'foremanReact/constants';
+import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
+import SeverityIcon from './SeverityIcon';
+import CveFindingsModal from './CveFindingsModal';
+import CveHistoryTable from './CveHistoryTable';
+import {
+  noReportsBody,
+  noReportsTitle,
+  riskLevelFromWorst,
+} from './cve_helpers';
+import './cve_scans.scss';
+
+const CveDetailsCard = ({ hostDetails }) => {
+  const hostId = hostDetails?.id;
+  const historyUrl = hostId
+    ? foremanUrl(`/api/v2/hosts/${hostId}/cve_scans?per_page=3`)
+    : null;
+  const latestUrl = hostId
+    ? foremanUrl(`/api/v2/hosts/${hostId}/cve_scans/latest`)
+    : null;
+  const { response: historyResponse, status } = useAPI('get', historyUrl, {
+    key: `CVE_DETAILS_${hostId}`,
+  });
+  const { response: latestResponse, status: latestStatus } = useAPI(
+    'get',
+    latestUrl,
+    { key: `CVE_DETAILS_LATEST_${hostId}` }
+  );
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalScanId, setModalScanId] = useState(null);
+  const [modalFilter, setModalFilter] = useState('all');
+  if (!hostId) return null;
+  const scans = historyResponse?.results || [];
+  const latest = latestResponse?.id ? latestResponse : scans[0];
+  const historyScans =
+    latest && Array.isArray(scans)
+      ? scans.filter(scan => scan.id !== latest.id)
+      : scans;
+  const findings = latest?.findings || [];
+  const sortedFindings = [...findings].sort((a, b) => {
+    const aTime = new Date(a.published || 0).getTime();
+    const bTime = new Date(b.published || 0).getTime();
+    return bTime - aTime;
+  });
+  const worst = latest?.summary?.worst || 'none';
+  const riskLevel = riskLevelFromWorst(worst);
+  const openModal = (scanId, filter) => {
+    setModalScanId(scanId);
+    setModalFilter(filter || 'all');
+    setIsModalOpen(true);
+  };
+  return (
+    <CardTemplate header={__('CVE scan details')} expandable masonryLayout>
+      <SkeletonLoader status={status || latestStatus || STATUS.PENDING}>
+        {!latest ? (
+          <EmptyState>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h4" size="md" ouiaId="cve-details-empty-title">
+              {noReportsTitle()}
+            </Title>
+            <EmptyStateBody>{noReportsBody()}</EmptyStateBody>
+          </EmptyState>
+        ) : (
+          <>
+            <DescriptionList isCompact isHorizontal>
+              <DescriptionListGroup>
+                <DescriptionListTerm>{__('Report')}</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <RelativeDateTime
+                    date={latest.created_at}
+                    defaultValue={__('Unknown time')}
+                  />
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>{__('Total')}</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Button
+                    variant="link"
+                    className="cve-summary-link"
+                    onClick={() => openModal(latest.id, 'all')}
+                    ouiaId="cve-details-total-button"
+                  >
+                    <span
+                      className={`cve-total-bubble cve-total-bubble--${riskLevel}`}
+                    >
+                      {latest.total}
+                    </span>
+                  </Button>{' '}
+                  {__('CVEs by')} {latest.scanner}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+            <div className="cve-counts cve-counts--compact">
+              <Button
+                variant="link"
+                className="cve-summary-link"
+                onClick={() => openModal(latest.id, 'critical')}
+                ouiaId="cve-details-critical-button"
+              >
+                <span className="cve-count">
+                  {__('critical')}
+                  <span className="cve-bubble">{latest.critical}</span>
+                </span>
+              </Button>
+              <Button
+                variant="link"
+                className="cve-summary-link"
+                onClick={() => openModal(latest.id, 'medium')}
+                ouiaId="cve-details-medium-button"
+              >
+                <span className="cve-count">
+                  {__('medium')}
+                  <span className="cve-bubble">{latest.medium}</span>
+                </span>
+              </Button>
+              <Button
+                variant="link"
+                className="cve-summary-link"
+                onClick={() => openModal(latest.id, 'high')}
+                ouiaId="cve-details-high-button"
+              >
+                <span className="cve-count">
+                  {__('high')}
+                  <span className="cve-bubble">{latest.high}</span>
+                </span>
+              </Button>
+              <Button
+                variant="link"
+                className="cve-summary-link"
+                onClick={() => openModal(latest.id, 'low')}
+                ouiaId="cve-details-low-button"
+              >
+                <span className="cve-count">
+                  {__('low')}
+                  <span className="cve-bubble">{latest.low}</span>
+                </span>
+              </Button>
+            </div>
+
+            {sortedFindings.length === 0 ? (
+              <Text component={TextVariants.small} ouiaId="cve-details-empty">
+                {__('No vulnerabilities reported')}
+              </Text>
+            ) : (
+              <>
+                <TextContent className="cve-section-title">
+                  <Text
+                    component={TextVariants.h5}
+                    ouiaId="cve-details-cves-title"
+                  >
+                    {__('CVEs')}
+                  </Text>
+                </TextContent>
+                <Table
+                  variant="compact"
+                  aria-label="CVE findings table"
+                  ouiaId="cve-details-findings-table"
+                >
+                  <Thead>
+                    <Tr ouiaId="cve-details-findings-header">
+                      <Th>{__('Severity')}</Th>
+                      <Th>{__('Package')}</Th>
+                      <Th>{__('Installed')}</Th>
+                    </Tr>
+                  </Thead>
+                  <Tbody>
+                    {sortedFindings.slice(0, 5).map((finding, index) => (
+                      <Tr
+                        key={finding.id}
+                        ouiaId={`cve-details-finding-row-${index}`}
+                      >
+                        <Td dataLabel={__('Severity')}>
+                          <span className="cve-summary">
+                            <SeverityIcon
+                              severity={finding.severity?.toLowerCase()}
+                            />
+                            <span>{finding.severity}</span>
+                          </span>
+                        </Td>
+                        <Td dataLabel={__('Package')}>{finding.name}</Td>
+                        <Td dataLabel={__('Installed')}>{finding.version}</Td>
+                      </Tr>
+                    ))}
+                  </Tbody>
+                </Table>
+                {sortedFindings.length > 5 && (
+                  <div className="cve-more">
+                    <Button
+                      variant="link"
+                      className="cve-summary-link"
+                      onClick={() => openModal(latest.id, 'all')}
+                      ouiaId="cve-details-more-button"
+                    >
+                      {__('More')}
+                    </Button>
+                  </div>
+                )}
+              </>
+            )}
+
+            {historyScans.length > 0 && (
+              <>
+                <TextContent className="cve-section-title">
+                  <Text
+                    component={TextVariants.h4}
+                    ouiaId="cve-details-recent-title"
+                  >
+                    {__('Recent scans')}
+                  </Text>
+                </TextContent>
+                <CveHistoryTable scans={historyScans} onOpen={openModal} />
+              </>
+            )}
+          </>
+        )}
+      </SkeletonLoader>
+      <CveFindingsModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        hostId={hostId}
+        scanId={modalScanId}
+        initialFilter={modalFilter}
+      />
+    </CardTemplate>
+  );
+};
+CveDetailsCard.propTypes = {
+  hostDetails: PropTypes.shape({ id: PropTypes.number }),
+};
+CveDetailsCard.defaultProps = {
+  hostDetails: undefined,
+};
+export default CveDetailsCard;

--- a/webpack/components/CveFindingsModal.js
+++ b/webpack/components/CveFindingsModal.js
@@ -1,0 +1,274 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable camelcase */
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Modal,
+  Button,
+  Text,
+  TextVariants,
+  FormGroup,
+} from '@patternfly/react-core';
+import {
+  Table,
+  Tbody,
+  Tr,
+  Th,
+  Thead,
+  Td,
+  SortByDirection,
+} from '@patternfly/react-table';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { STATUS } from 'foremanReact/constants';
+import SeverityIcon from './SeverityIcon';
+import { compareStrings, formatDateTime, severityRank } from './cve_helpers';
+import './cve_scans.scss';
+
+const SEVERITY_OPTIONS = ['all', 'critical', 'high', 'medium', 'low'];
+const COLUMNS = [
+  { key: 'severity', label: __('Severity') },
+  { key: 'published', label: __('Published') },
+  { key: 'name', label: __('Package') },
+  { key: 'version', label: __('Affected version') },
+  { key: 'fixed', label: __('Fixed version') },
+  { key: 'status', label: __('Status') },
+  { key: 'id', label: __('CVE') },
+  { key: 'title', label: __('Title') },
+];
+
+const CveFindingsModal = ({
+  isOpen,
+  onClose,
+  hostId,
+  scanId,
+  initialFilter,
+}) => {
+  const [filter, setFilter] = useState(initialFilter || 'all');
+  const [sortBy, setSortBy] = useState({
+    direction: SortByDirection.desc,
+    column: 'severity',
+  });
+  const normalizedScanId =
+    scanId !== null && scanId !== undefined && String(scanId).trim() !== ''
+      ? scanId
+      : null;
+  const url = normalizedScanId
+    ? foremanUrl(`/api/v2/hosts/${hostId}/cve_scans/${normalizedScanId}`)
+    : foremanUrl(`/api/v2/hosts/${hostId}/cve_scans/latest`);
+
+  const { response, status } = useAPI(isOpen ? 'get' : null, url, {
+    key: `CVE_SCAN_${normalizedScanId || 'latest'}`,
+  });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setFilter(initialFilter || 'all');
+  }, [initialFilter, isOpen, scanId]);
+
+  const payload = response || {};
+  const findings = Array.isArray(payload.findings) ? payload.findings : [];
+
+  const normalizedFilter = (filter || 'all').toLowerCase();
+  const filteredFindings = useMemo(() => {
+    if (normalizedFilter === 'all') return findings;
+    return findings.filter(
+      f => (f.severity || '').toLowerCase() === normalizedFilter
+    );
+  }, [normalizedFilter, findings]);
+
+  const formatPublished = formatDateTime;
+
+  const sorters = useMemo(
+    () => ({
+      published: (a, b) =>
+        new Date(a.published || 0) - new Date(b.published || 0),
+      name: (a, b) => compareStrings(a.name, b.name),
+      version: (a, b) => compareStrings(a.version, b.version),
+      fixed: (a, b) => compareStrings(a.fixed, b.fixed),
+      id: (a, b) => compareStrings(a.id, b.id),
+      status: (a, b) => compareStrings(a.status, b.status),
+      title: (a, b) => compareStrings(a.title, b.title),
+      severity: (a, b) => severityRank(a.severity) - severityRank(b.severity),
+    }),
+    []
+  );
+  const sortedFindings = useMemo(() => {
+    const list = [...filteredFindings];
+    const sortKey = sortBy.column || 'severity';
+    const sorter = sorters[sortKey] || sorters.severity;
+    list.sort((a, b) => {
+      const result = sorter(a, b);
+      return sortBy.direction === SortByDirection.asc ? result : -result;
+    });
+    return list;
+  }, [filteredFindings, sortBy, sorters]);
+
+  const onSort = column => {
+    const nextDirection =
+      sortBy.column === column && sortBy.direction === SortByDirection.asc
+        ? SortByDirection.desc
+        : SortByDirection.asc;
+    setSortBy({ column, direction: nextDirection });
+  };
+
+  return (
+    <Modal
+      title={
+        payload?.created_at && typeof payload?.total !== 'undefined'
+          ? `${__('Report from')} ${formatPublished(payload.created_at)} - ${__(
+              'Total'
+            )}: ${payload.total}`
+          : __('CVE findings')
+      }
+      isOpen={isOpen}
+      onClose={onClose}
+      width="70%"
+      maxWidth="70%"
+      ouiaId="cve-findings-modal"
+      actions={[
+        <Button
+          key="close"
+          variant="primary"
+          onClick={onClose}
+          ouiaId="cve-findings-close"
+        >
+          {__('Close')}
+        </Button>,
+      ]}
+    >
+      {status === STATUS.PENDING ? (
+        <Text component={TextVariants.small} ouiaId="cve-findings-loading">
+          {__('Loading...')}
+        </Text>
+      ) : (
+        <div className="cve-modal-body">
+          <div className="cve-modal-filters">
+            <FormGroup fieldId="cve-filter">
+              <div className="cve-filter-buttons">
+                {SEVERITY_OPTIONS.map(opt => (
+                  <button
+                    key={opt}
+                    type="button"
+                    aria-pressed={filter === opt}
+                    className={
+                      filter === opt
+                        ? 'cve-filter-button is-active'
+                        : 'cve-filter-button'
+                    }
+                    onClick={() => setFilter(opt)}
+                  >
+                    {__(opt)}
+                  </button>
+                ))}
+              </div>
+            </FormGroup>
+          </div>
+
+          {response?.error && (
+            <Text component={TextVariants.small} ouiaId="cve-findings-error">
+              {response.error.message}
+            </Text>
+          )}
+          {sortedFindings.length === 0 && !response?.error ? (
+            <Text component={TextVariants.small} ouiaId="cve-findings-empty">
+              {__('No findings for selected filter')}
+            </Text>
+          ) : (
+            <Table
+              variant="compact"
+              aria-label="CVE findings table"
+              ouiaId="cve-findings-table"
+            >
+              <Thead>
+                <Tr ouiaId="cve-findings-header">
+                  {COLUMNS.map(col => (
+                    <Th
+                      key={col.key}
+                      className={`cve-col-${col.key} cve-sortable`}
+                      aria-label={
+                        col.key === 'severity' ? __('Severity') : undefined
+                      }
+                      onClick={() => onSort(col.key)}
+                    >
+                      {col.key === 'severity' ? (
+                        <SeverityIcon severity="high" />
+                      ) : (
+                        col.label
+                      )}
+                      {sortBy.column === col.key && (
+                        <span className="cve-sort-indicator">
+                          {sortBy.direction === SortByDirection.asc
+                            ? ' ▲'
+                            : ' ▼'}
+                        </span>
+                      )}
+                    </Th>
+                  ))}
+                </Tr>
+              </Thead>
+              <Tbody>
+                {sortedFindings.map((finding, index) => (
+                  <Tr key={finding.id} ouiaId={`cve-findings-row-${index}`}>
+                    <Td dataLabel={__('Severity')}>
+                      <span
+                        className="cve-summary cve-summary--icon-only"
+                        title={finding.severity}
+                        aria-label={finding.severity}
+                      >
+                        <SeverityIcon
+                          severity={(finding.severity || '').toLowerCase()}
+                        />
+                      </span>
+                    </Td>
+                    <Td dataLabel={__('Published')}>
+                      {formatPublished(finding.published)}
+                    </Td>
+                    <Td dataLabel={__('Package')}>{finding.name}</Td>
+                    <Td dataLabel={__('Affected version')}>
+                      {finding.version}
+                    </Td>
+                    <Td dataLabel={__('Fixed version')} title={finding.fixed}>
+                      <span className="cve-truncate">{finding.fixed}</span>
+                    </Td>
+                    <Td dataLabel={__('Status')}>
+                      {finding.status || __('open')}
+                    </Td>
+                    <Td dataLabel={__('CVE')}>
+                      {finding.url ? (
+                        <a href={finding.url} target="_blank" rel="noreferrer">
+                          {finding.id}
+                        </a>
+                      ) : (
+                        finding.id
+                      )}
+                    </Td>
+                    <Td dataLabel={__('Title')} title={finding.title}>
+                      <span className="cve-truncate">{finding.title}</span>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+CveFindingsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  hostId: PropTypes.number.isRequired,
+  scanId: PropTypes.number,
+  initialFilter: PropTypes.string,
+};
+
+CveFindingsModal.defaultProps = {
+  scanId: undefined,
+  initialFilter: 'all',
+};
+
+export default CveFindingsModal;

--- a/webpack/components/CveHistoryTable.js
+++ b/webpack/components/CveHistoryTable.js
@@ -1,0 +1,58 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { Button } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
+
+const CveHistoryTable = ({ scans, onOpen }) => (
+  <Table
+    variant="compact"
+    aria-label="CVE scan history table"
+    ouiaId="cve-details-history-table"
+  >
+    <Thead>
+      <Tr ouiaId="cve-details-history-header">
+        <Th>{__('Reported at')}</Th>
+        <Th>{__('Scanner')}</Th>
+        <Th>{__('Total')}</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      {scans.map((scan, index) => (
+        <Tr key={scan.id} ouiaId={`cve-details-history-row-${index}`}>
+          <Td dataLabel={__('Reported at')}>
+            <Button
+              variant="link"
+              className="cve-summary-link"
+              onClick={() => onOpen(scan.id, 'all')}
+              ouiaId={`cve-details-history-open-${scan.id}`}
+            >
+              <RelativeDateTime
+                date={scan.created_at}
+                defaultValue={__('Unknown time')}
+              />
+            </Button>
+          </Td>
+          <Td dataLabel={__('Scanner')}>{scan.scanner}</Td>
+          <Td dataLabel={__('Total')}>{scan.total}</Td>
+        </Tr>
+      ))}
+    </Tbody>
+  </Table>
+);
+
+CveHistoryTable.propTypes = {
+  scans: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      created_at: PropTypes.string,
+      scanner: PropTypes.string,
+      total: PropTypes.number,
+    })
+  ).isRequired,
+  onOpen: PropTypes.func.isRequired,
+};
+
+export default CveHistoryTable;

--- a/webpack/components/CveOverviewCard.js
+++ b/webpack/components/CveOverviewCard.js
@@ -1,0 +1,67 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
+import SkeletonLoader from 'foremanReact/components/common/SkeletonLoader';
+import { STATUS } from 'foremanReact/constants';
+import SeverityIcon from './SeverityIcon';
+import { noReportsTitle } from './cve_helpers';
+import './cve_scans.scss';
+
+const CveOverviewCard = ({ hostDetails }) => {
+  const hostId = hostDetails?.id;
+  const url = hostId
+    ? foremanUrl(`/api/v2/hosts/${hostId}/cve_scans/latest`)
+    : null;
+  const { response, status } = useAPI('get', url, {
+    key: `CVE_OVERVIEW_${hostId}`,
+  });
+
+  if (!hostId) return null;
+
+  const total = response?.total || 0;
+  const worst = response?.summary?.worst || 'none';
+
+  return (
+    <CardTemplate header={__('CVE findings')}>
+      <SkeletonLoader status={status || STATUS.PENDING}>
+        {!response ? (
+          <TextContent ouiaId="cve-overview-empty">
+            <Text
+              component={TextVariants.small}
+              ouiaId="cve-overview-empty-text"
+            >
+              {noReportsTitle()}
+            </Text>
+          </TextContent>
+        ) : (
+          <div className="cve-overview">
+            <div className="cve-summary">
+              <SeverityIcon severity={worst} />
+              <Text component={TextVariants.h2} ouiaId="cve-overview-total">
+                {total}
+              </Text>
+            </div>
+            <Text component={TextVariants.small} ouiaId="cve-overview-caption">
+              {__('Total findings in latest scan')}
+            </Text>
+          </div>
+        )}
+      </SkeletonLoader>
+    </CardTemplate>
+  );
+};
+
+CveOverviewCard.propTypes = {
+  hostDetails: PropTypes.shape({ id: PropTypes.number }),
+};
+
+CveOverviewCard.defaultProps = {
+  hostDetails: undefined,
+};
+
+export default CveOverviewCard;

--- a/webpack/components/CveScansTab.js
+++ b/webpack/components/CveScansTab.js
@@ -1,0 +1,192 @@
+/* eslint-disable import/no-unresolved */
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Pagination,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Title,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import SkeletonLoader from 'foremanReact/components/common/SkeletonLoader';
+import { STATUS } from 'foremanReact/constants';
+import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
+import CveFindingsModal from './CveFindingsModal';
+import { noReportsBody, noReportsTitle } from './cve_helpers';
+
+const DEFAULT_PER_PAGE = 20;
+
+const CveScansTab = ({ response }) => {
+  const hostId = response?.id;
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalScanId, setModalScanId] = useState(null);
+  const [modalFilter, setModalFilter] = useState('all');
+
+  const historyUrl = hostId
+    ? foremanUrl(
+        `/api/v2/hosts/${hostId}/cve_scans?page=${page}&per_page=${perPage}`
+      )
+    : null;
+  const { response: apiResponse, status } = useAPI('get', historyUrl, {
+    key: `CVE_SCANS_TAB_${hostId}_${page}_${perPage}`,
+  });
+
+  const scans = useMemo(() => apiResponse?.results || [], [apiResponse]);
+  const itemCount = apiResponse?.total ?? scans.length;
+  if (!hostId) return null;
+
+  const openModal = (scanId, filter) => {
+    setModalScanId(scanId);
+    setModalFilter(filter || 'all');
+    setIsModalOpen(true);
+  };
+
+  const onSetPage = (_event, newPage) => setPage(newPage);
+  const onPerPageSelect = (_event, newPerPage) => {
+    setPerPage(newPerPage);
+    setPage(1);
+  };
+
+  return (
+    <>
+      <SkeletonLoader status={status || STATUS.PENDING}>
+        {scans.length === 0 ? (
+          <EmptyState>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h4" size="md" ouiaId="cve-scans-empty-title">
+              {noReportsTitle()}
+            </Title>
+            <EmptyStateBody>{noReportsBody()}</EmptyStateBody>
+          </EmptyState>
+        ) : (
+          <>
+            <Pagination
+              itemCount={itemCount}
+              perPage={perPage}
+              page={page}
+              onSetPage={onSetPage}
+              onPerPageSelect={onPerPageSelect}
+              variant="top"
+              isCompact
+              ouiaId="cve-scans-pagination"
+            />
+            <Table
+              variant="compact"
+              aria-label="CVE scans history"
+              ouiaId="cve-scans-table"
+            >
+              <Thead>
+                <Tr ouiaId="cve-scans-header">
+                  <Th>{__('Reported at')}</Th>
+                  <Th>{__('Scanner')}</Th>
+                  <Th>{__('Total')}</Th>
+                  <Th>{__('Critical')}</Th>
+                  <Th>{__('High')}</Th>
+                  <Th>{__('Medium')}</Th>
+                  <Th>{__('Low')}</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {scans.map((scan, index) => (
+                  <Tr key={scan.id} ouiaId={`cve-scans-row-${index}`}>
+                    <Td dataLabel={__('Reported at')}>
+                      <Button
+                        variant="link"
+                        className="cve-summary-link"
+                        onClick={() => openModal(scan.id, 'all')}
+                        ouiaId={`cve-scans-open-${scan.id}`}
+                      >
+                        <RelativeDateTime
+                          date={scan.created_at}
+                          defaultValue={__('Unknown time')}
+                        />
+                      </Button>
+                    </Td>
+                    <Td dataLabel={__('Scanner')}>{scan.scanner}</Td>
+                    <Td dataLabel={__('Total')}>
+                      <Button
+                        variant="link"
+                        className="cve-summary-link"
+                        onClick={() => openModal(scan.id, 'all')}
+                        ouiaId={`cve-scans-total-${scan.id}`}
+                      >
+                        {scan.total}
+                      </Button>
+                    </Td>
+                    <Td dataLabel={__('Critical')}>
+                      <Button
+                        variant="link"
+                        className="cve-summary-link"
+                        onClick={() => openModal(scan.id, 'critical')}
+                        ouiaId={`cve-scans-critical-${scan.id}`}
+                      >
+                        {scan.critical}
+                      </Button>
+                    </Td>
+                    <Td dataLabel={__('High')}>
+                      <Button
+                        variant="link"
+                        className="cve-summary-link"
+                        onClick={() => openModal(scan.id, 'high')}
+                        ouiaId={`cve-scans-high-${scan.id}`}
+                      >
+                        {scan.high}
+                      </Button>
+                    </Td>
+                    <Td dataLabel={__('Medium')}>
+                      <Button
+                        variant="link"
+                        className="cve-summary-link"
+                        onClick={() => openModal(scan.id, 'medium')}
+                        ouiaId={`cve-scans-medium-${scan.id}`}
+                      >
+                        {scan.medium}
+                      </Button>
+                    </Td>
+                    <Td dataLabel={__('Low')}>
+                      <Button
+                        variant="link"
+                        className="cve-summary-link"
+                        onClick={() => openModal(scan.id, 'low')}
+                        ouiaId={`cve-scans-low-${scan.id}`}
+                      >
+                        {scan.low}
+                      </Button>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </>
+        )}
+      </SkeletonLoader>
+      <CveFindingsModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        hostId={hostId}
+        scanId={modalScanId}
+        initialFilter={modalFilter}
+      />
+    </>
+  );
+};
+
+CveScansTab.propTypes = {
+  response: PropTypes.shape({
+    id: PropTypes.number,
+  }),
+};
+
+CveScansTab.defaultProps = {
+  response: undefined,
+};
+
+export default CveScansTab;

--- a/webpack/components/CveSummaryCell.js
+++ b/webpack/components/CveSummaryCell.js
@@ -1,0 +1,72 @@
+/* eslint-disable import/no-unresolved */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Spinner } from '@patternfly/react-core';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { STATUS } from 'foremanReact/constants';
+import SeverityIcon from './SeverityIcon';
+import CveFindingsModal from './CveFindingsModal';
+import './cve_scans.scss';
+
+const CveSummaryCell = ({ hostId, hostName }) => {
+  const url = hostId
+    ? foremanUrl(`/api/v2/hosts/${hostId}/cve_scans/latest`)
+    : null;
+  const { response, status } = useAPI('get', url, {
+    key: `CVE_SUMMARY_${hostId}`,
+  });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  if (!hostId) return <span className="cve-summary-empty">--</span>;
+  if (status === STATUS.PENDING) {
+    return (
+      <Spinner
+        size="sm"
+        aria-label={__('Loading CVE findings')}
+        ouiaId="cve-summary-loading"
+      />
+    );
+  }
+
+  if (!response) return <span className="cve-summary-empty">--</span>;
+
+  const total = response.total || 0;
+  const worst = response.summary?.worst || 'none';
+  const scanId = response.id;
+  const title = `${hostName || __('Host')}: ${total} ${__('findings')}`;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="cve-summary cve-summary-link"
+        title={title}
+        onClick={() => setIsModalOpen(true)}
+      >
+        <SeverityIcon severity={worst} />
+        <span className="cve-summary-count">{total}</span>
+      </button>
+      <CveFindingsModal
+        isOpen={isModalOpen && !!scanId}
+        onClose={() => setIsModalOpen(false)}
+        hostId={hostId}
+        scanId={scanId}
+        initialFilter="all"
+      />
+    </>
+  );
+};
+
+CveSummaryCell.propTypes = {
+  hostId: PropTypes.number,
+  hostName: PropTypes.string,
+};
+
+CveSummaryCell.defaultProps = {
+  hostId: undefined,
+  hostName: undefined,
+};
+
+export default CveSummaryCell;

--- a/webpack/components/SeverityIcon.js
+++ b/webpack/components/SeverityIcon.js
@@ -1,0 +1,56 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon,
+  CheckCircleIcon,
+} from '@patternfly/react-icons';
+import { Icon } from '@patternfly/react-core';
+import './cve_scans.scss';
+
+const SeverityIcon = ({ severity }) => {
+  switch (severity) {
+    case 'critical':
+      return (
+        <Icon className="cve-severity cve-severity--critical">
+          <ExclamationCircleIcon />
+        </Icon>
+      );
+    case 'high':
+      return (
+        <Icon className="cve-severity cve-severity--high">
+          <ExclamationTriangleIcon />
+        </Icon>
+      );
+    case 'medium':
+      return (
+        <Icon className="cve-severity cve-severity--medium">
+          <InfoCircleIcon />
+        </Icon>
+      );
+    case 'low':
+      return (
+        <Icon className="cve-severity cve-severity--low">
+          <InfoCircleIcon />
+        </Icon>
+      );
+    default:
+      return (
+        <Icon className="cve-severity cve-severity--none">
+          <CheckCircleIcon />
+        </Icon>
+      );
+  }
+};
+
+SeverityIcon.propTypes = {
+  severity: PropTypes.string,
+};
+
+SeverityIcon.defaultProps = {
+  severity: 'none',
+};
+
+export default SeverityIcon;

--- a/webpack/components/__tests__/CveDetailsCard.test.js
+++ b/webpack/components/__tests__/CveDetailsCard.test.js
@@ -1,0 +1,126 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import { mount } from 'enzyme';
+import CveDetailsCard from '../CveDetailsCard';
+
+jest.mock('foremanReact/common/hooks/API/APIHooks', () => ({
+  useAPI: jest.fn(),
+}));
+
+jest.mock('foremanReact/components/HostDetails/Templates/CardItem/CardTemplate', () => (
+  { children }
+) => <div>{children}</div>);
+
+jest.mock('foremanReact/components/common/SkeletonLoader', () => (
+  { children }
+) => <div>{children}</div>);
+
+jest.mock('foremanReact/components/common/dates/RelativeDateTime', () => (
+  { date, defaultValue }
+) => <span>{date || defaultValue}</span>);
+
+jest.mock('../CveFindingsModal', () => () => <div data-test="modal" />);
+
+const { useAPI } = require('foremanReact/common/hooks/API/APIHooks');
+
+describe('CveDetailsCard', () => {
+  beforeEach(() => {
+    useAPI.mockReset();
+  });
+
+  it('renders recent scans and findings', () => {
+    const hostDetails = { id: 1 };
+    const historyResponse = {
+      results: [
+        { id: 1, created_at: '2026-02-20', scanner: 'trivy', total: 10 },
+        { id: 2, created_at: '2026-02-21', scanner: 'trivy', total: 12 },
+        { id: 3, created_at: '2026-02-22', scanner: 'grype', total: 8 },
+      ],
+    };
+    const latestResponse = {
+      id: 3,
+      created_at: '2026-02-22',
+      scanner: 'grype',
+      total: 8,
+      summary: { worst: 'high' },
+      critical: 1,
+      high: 1,
+      medium: 2,
+      low: 4,
+      findings: [
+        {
+          id: 'CVE-1',
+          name: 'pkg',
+          version: '1.0',
+          severity: 'HIGH',
+          published: '2026-02-10',
+        },
+      ],
+    };
+
+    useAPI.mockImplementation((_method, url) => {
+      if (url && url.includes('/latest')) {
+        return { response: latestResponse, status: 'RESOLVED' };
+      }
+      return { response: historyResponse, status: 'RESOLVED' };
+    });
+
+    const wrapper = mount(<CveDetailsCard hostDetails={hostDetails} />);
+
+    expect(wrapper.text()).toContain('Recent scans');
+    expect(wrapper.find('table').length).toBeGreaterThan(0);
+    expect(wrapper.text()).toContain('CVEs');
+    expect(wrapper.text()).toContain('pkg');
+  });
+
+  it('falls back to history when latest is empty', () => {
+    const hostDetails = { id: 1 };
+    const historyResponse = {
+      results: [{ id: 1, created_at: '2026-02-20', scanner: 'trivy', total: 10 }],
+    };
+
+    useAPI.mockImplementation((_method, url) => {
+      if (url && url.includes('/latest')) {
+        return { response: {}, status: 'RESOLVED' };
+      }
+      return { response: historyResponse, status: 'RESOLVED' };
+    });
+
+    const wrapper = mount(<CveDetailsCard hostDetails={hostDetails} />);
+    expect(wrapper.text()).toContain('Report');
+    expect(wrapper.text()).toContain('trivy');
+  });
+
+  it('prefers latest when present', () => {
+    const hostDetails = { id: 1 };
+    const historyResponse = {
+      results: [{ id: 1, created_at: '2026-02-20', scanner: 'trivy', total: 10 }],
+    };
+    const latestResponse = {
+      id: 2,
+      created_at: '2026-02-21',
+      scanner: 'grype',
+      total: 8,
+      summary: { worst: 'high' },
+      findings: [],
+    };
+
+    useAPI.mockImplementation((_method, url) => {
+      if (url && url.includes('/latest')) {
+        return { response: latestResponse, status: 'RESOLVED' };
+      }
+      return { response: historyResponse, status: 'RESOLVED' };
+    });
+
+    const wrapper = mount(<CveDetailsCard hostDetails={hostDetails} />);
+    expect(wrapper.text()).toContain('grype');
+  });
+
+  it('renders empty state when no scans', () => {
+    const hostDetails = { id: 1 };
+    useAPI.mockReturnValue({ response: null, status: 'RESOLVED' });
+
+    const wrapper = mount(<CveDetailsCard hostDetails={hostDetails} />);
+    expect(wrapper.text()).toContain('No CVE reports for this host');
+  });
+});

--- a/webpack/components/__tests__/CveFindingsModal.test.js
+++ b/webpack/components/__tests__/CveFindingsModal.test.js
@@ -1,0 +1,78 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import { mount } from 'enzyme';
+import CveFindingsModal from '../CveFindingsModal';
+
+jest.mock('foremanReact/common/hooks/API/APIHooks', () => ({
+  useAPI: jest.fn(),
+}));
+
+const { useAPI } = require('foremanReact/common/hooks/API/APIHooks');
+
+describe('CveFindingsModal', () => {
+  beforeEach(() => {
+    useAPI.mockReset();
+  });
+
+  it('filters findings by severity', () => {
+    useAPI.mockReturnValue({
+      response: {
+        id: 1,
+        created_at: '2026-02-22T10:00:00Z',
+        total: 2,
+        findings: [
+          { id: 'CVE-1', severity: 'HIGH', name: 'a', version: '1' },
+          { id: 'CVE-2', severity: 'LOW', name: 'b', version: '2' },
+        ],
+      },
+      status: 'RESOLVED',
+    });
+
+    const wrapper = mount(
+      <CveFindingsModal
+        isOpen
+        onClose={() => {}}
+        hostId={1}
+        scanId={1}
+        initialFilter="all"
+      />
+    );
+
+    expect(wrapper.text()).toContain('CVE-1');
+    expect(wrapper.text()).toContain('CVE-2');
+
+    const lowButton = wrapper
+      .find('button')
+      .filterWhere(node => node.text().toLowerCase() === 'low')
+      .first();
+    lowButton.simulate('click');
+    wrapper.update();
+
+    expect(wrapper.text()).toContain('CVE-2');
+    expect(wrapper.text()).not.toContain('CVE-1');
+  });
+
+  it('shows empty state when no findings', () => {
+    useAPI.mockReturnValue({
+      response: {
+        id: 1,
+        created_at: '2026-02-22T10:00:00Z',
+        total: 0,
+        findings: [],
+      },
+      status: 'RESOLVED',
+    });
+
+    const wrapper = mount(
+      <CveFindingsModal
+        isOpen
+        onClose={() => {}}
+        hostId={1}
+        scanId={1}
+        initialFilter="all"
+      />
+    );
+
+    expect(wrapper.text()).toContain('No findings for selected filter');
+  });
+});

--- a/webpack/components/__tests__/CveScansTab.test.js
+++ b/webpack/components/__tests__/CveScansTab.test.js
@@ -1,0 +1,76 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import { mount } from 'enzyme';
+import CveScansTab from '../CveScansTab';
+
+jest.mock('foremanReact/common/hooks/API/APIHooks', () => ({
+  useAPI: jest.fn(),
+}));
+
+jest.mock('foremanReact/components/common/SkeletonLoader', () => (
+  { children }
+) => <div>{children}</div>);
+
+jest.mock('foremanReact/components/common/dates/RelativeDateTime', () => (
+  { date, defaultValue }
+) => <span>{date || defaultValue}</span>);
+
+jest.mock('../CveFindingsModal', () => () => <div data-test="modal" />);
+
+const { useAPI } = require('foremanReact/common/hooks/API/APIHooks');
+
+describe('CveScansTab', () => {
+  beforeEach(() => {
+    useAPI.mockReset();
+  });
+
+  it('renders rows for scans', () => {
+    const scansResponse = {
+      results: [
+        {
+          id: 1,
+          created_at: '2026-02-20',
+          scanner: 'trivy',
+          total: 10,
+          critical: 1,
+          high: 2,
+          medium: 3,
+          low: 4,
+        },
+        {
+          id: 2,
+          created_at: '2026-02-21',
+          scanner: 'grype',
+          total: 5,
+          critical: 0,
+          high: 1,
+          medium: 1,
+          low: 3,
+        },
+      ],
+      total: 2,
+    };
+
+    useAPI.mockReturnValue({ response: scansResponse, status: 'RESOLVED' });
+
+    const wrapper = mount(<CveScansTab response={{ id: 1 }} />);
+
+    expect(wrapper.text()).toContain('Reported at');
+    expect(wrapper.text()).toContain('trivy');
+    expect(wrapper.text()).toContain('grype');
+  });
+
+  it('renders empty state with no scans', () => {
+    useAPI.mockReturnValue({ response: { results: [] }, status: 'RESOLVED' });
+
+    const wrapper = mount(<CveScansTab response={{ id: 1 }} />);
+    expect(wrapper.text()).toContain('No CVE reports for this host');
+  });
+
+  it('does not render when host id is missing', () => {
+    useAPI.mockReturnValue({ response: { results: [] }, status: 'RESOLVED' });
+
+    const wrapper = mount(<CveScansTab response={{}} />);
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+});

--- a/webpack/components/__tests__/cve_helpers.test.js
+++ b/webpack/components/__tests__/cve_helpers.test.js
@@ -1,0 +1,42 @@
+/* eslint-disable import/no-unresolved */
+import {
+  severityRank,
+  riskLevelFromWorst,
+  formatDateTime,
+  compareStrings,
+} from '../cve_helpers';
+
+describe('cve_helpers', () => {
+  it('maps severity ranks', () => {
+    expect(severityRank('CRITICAL')).toBe(4);
+    expect(severityRank('high')).toBe(3);
+    expect(severityRank('MEDIUM')).toBe(2);
+    expect(severityRank('low')).toBe(1);
+    expect(severityRank('unknown')).toBe(0);
+  });
+
+  it('maps risk levels from worst', () => {
+    expect(riskLevelFromWorst('critical')).toBe('high');
+    expect(riskLevelFromWorst('high')).toBe('high');
+    expect(riskLevelFromWorst('medium')).toBe('medium');
+    expect(riskLevelFromWorst('low')).toBe('low');
+    expect(riskLevelFromWorst('none')).toBe('none');
+  });
+
+  it('formats dates into yyyy-mm-dd hh:mm', () => {
+    const result = formatDateTime('2026-02-22T10:05:00Z');
+    expect(result).toContain('2026-02-22');
+    expect(result).toContain('10:05');
+  });
+
+  it('returns input when date is invalid', () => {
+    expect(formatDateTime('not-a-date')).toBe('not-a-date');
+  });
+
+  it('compares strings safely', () => {
+    expect(compareStrings('a', 'b')).toBeLessThan(0);
+    expect(compareStrings('b', 'a')).toBeGreaterThan(0);
+    expect(compareStrings('a', 'a')).toBe(0);
+    expect(compareStrings(null, 'a')).toBeLessThan(0);
+  });
+});

--- a/webpack/components/cve_helpers.js
+++ b/webpack/components/cve_helpers.js
@@ -1,0 +1,35 @@
+/* eslint-disable import/no-unresolved */
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const SEVERITY_RANK = {
+  CRITICAL: 4,
+  HIGH: 3,
+  MEDIUM: 2,
+  LOW: 1,
+};
+
+export const severityRank = sev =>
+  SEVERITY_RANK[(sev || '').toUpperCase()] || 0;
+
+export const riskLevelFromWorst = worst => {
+  if (['critical', 'high'].includes(worst)) return 'high';
+  if (worst === 'medium') return 'medium';
+  if (worst === 'low') return 'low';
+  return 'none';
+};
+
+export const formatDateTime = value => {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return value;
+  const pad = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(
+    d.getHours()
+  )}:${pad(d.getMinutes())}`;
+};
+
+export const compareStrings = (a, b) =>
+  (a || '').toString().localeCompare((b || '').toString());
+
+export const noReportsTitle = () => __('No CVE reports for this host');
+export const noReportsBody = () => __('Run a CVE scan to see results here.');

--- a/webpack/components/cve_scans.scss
+++ b/webpack/components/cve_scans.scss
@@ -1,0 +1,200 @@
+.cve-summary {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.cve-summary-count {
+  font-weight: 600;
+}
+
+.cve-section-title {
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.cve-severity {
+  display: inline-flex;
+}
+
+.cve-severity--critical,
+.cve-severity--high {
+  color: var(--pf-v5-global--danger-color--100);
+}
+
+.cve-severity--medium {
+  color: var(--pf-v5-global--warning-color--100);
+}
+
+.cve-severity--low {
+  color: var(--pf-v5-global--palette--blue-400);
+}
+
+.cve-severity--none {
+  color: var(--pf-v5-global--success-color--100);
+}
+
+.cve-summary-empty {
+  color: var(--pf-v5-global--disabled-color--200);
+}
+
+.cve-summary-link {
+  padding: 0;
+  margin: 0;
+}
+
+button.cve-summary {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+}
+
+.cve-count {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.cve-bubble {
+  align-items: center;
+  background: var(--pf-v5-global--palette--blue-200);
+  border-radius: 1em;
+  color: var(--pf-v5-global--palette--blue-600);
+  display: inline-flex;
+  font-weight: 600;
+  padding: 0 0.5rem;
+}
+
+.cve-total-bubble {
+  align-items: center;
+  border-radius: 1em;
+  display: inline-flex;
+  font-weight: 700;
+  padding: 0 0.5rem;
+}
+
+.cve-total-bubble--high {
+  background: var(--pf-v5-global--danger-color--100);
+  color: var(--pf-v5-global--BackgroundColor--100);
+}
+
+.cve-total-bubble--medium {
+  background: var(--pf-v5-global--warning-color--100);
+  color: var(--pf-v5-global--BackgroundColor--100);
+}
+
+.cve-total-bubble--low {
+  background: var(--pf-v5-global--palette--blue-400);
+  color: var(--pf-v5-global--BackgroundColor--100);
+}
+
+.cve-total-bubble--none {
+  background: var(--pf-v5-global--success-color--100);
+  color: var(--pf-v5-global--BackgroundColor--100);
+}
+
+.cve-counts {
+  display: grid;
+  gap: 0.35rem 1rem;
+  grid-template-columns: auto auto;
+  margin-top: 0.25rem;
+}
+
+.cve-counts--compact {
+  column-gap: 0.5rem;
+  row-gap: 0.25rem;
+  margin-top: 0.15rem;
+}
+
+.cve-filter-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cve-sort-indicator {
+  font-size: 0.85em;
+}
+
+.cve-sortable {
+  cursor: pointer;
+}
+
+.cve-filter-button.is-active {
+  box-shadow: 0 0 0 2px var(--pf-v5-global--primary-color--100) inset;
+}
+
+.cve-filter-button {
+  background: var(--pf-v5-global--BackgroundColor--100);
+  border: 1px solid var(--pf-v5-global--BorderColor--100);
+  border-radius: 2px;
+  color: var(--pf-v5-global--Color--100);
+  cursor: pointer;
+  font: inherit;
+  padding: 0.25rem 0.75rem;
+}
+
+.cve-modal-body {
+  position: relative;
+  min-height: 420px;
+}
+
+.cve-modal-filters {
+  position: relative;
+  z-index: 1;
+}
+
+.cve-more {
+  margin-top: 0.5rem;
+}
+
+.cve-truncate {
+  display: inline-block;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
+.cve-col-severity {
+  width: 28px;
+}
+
+.cve-col-published {
+  width: 210px;
+}
+
+.cve-col-name {
+  width: 200px;
+}
+
+.cve-col-version {
+  width: 180px;
+}
+
+.cve-col-fixed {
+  width: 160px;
+}
+
+.cve-col-status {
+  width: 90px;
+}
+
+.cve-col-id {
+  width: 150px;
+}
+
+.cve-col-title {
+  width: 240px;
+}
+
+.cve-summary--icon-only {
+  width: 18px;
+}
+
+.cve-col-published,
+.cve-col-published * {
+  white-space: nowrap;
+}

--- a/webpack/fills.js
+++ b/webpack/fills.js
@@ -1,0 +1,1 @@
+import './fills_index';

--- a/webpack/fills_index.js
+++ b/webpack/fills_index.js
@@ -1,0 +1,38 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
+import { registerColumns } from 'foremanReact/components/HostsIndex/Columns/core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import CveDetailsCard from './components/CveDetailsCard';
+import CveScansTab from './components/CveScansTab';
+import CveSummaryCell from './components/CveSummaryCell';
+
+addGlobalFill(
+  'host-tab-details-cards',
+  'foreman-cve-scanner-details-card',
+  <CveDetailsCard key="foreman-cve-scanner-details-card" />,
+  2200
+);
+
+addGlobalFill(
+  'host-details-page-tabs',
+  'CVE scans',
+  <CveScansTab key="foreman-cve-scanner-scans-tab" />,
+  450,
+  { title: __('CVE scans') }
+);
+
+registerColumns([
+  {
+    columnName: 'cve_findings',
+    title: __('CVE'),
+    wrapper: hostDetails => (
+      <CveSummaryCell hostId={hostDetails?.id} hostName={hostDetails?.name} />
+    ),
+    weight: 450,
+    tableName: 'hosts',
+    categoryName: __('Security'),
+    categoryKey: 'security',
+    isSorted: false,
+  },
+]);

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,0 +1,1 @@
+import './fills_index';


### PR DESCRIPTION
This huge PR changes the following:
- remove config report
- adds host overview column (for new host overview page)
- add host details card
- add hosts details tab
- details card and tab uses modal view to display a report
- add hosts CVE status
- add run CVE scan button
- add api to receive the cve scans
- adds tests

host status:
<img width="930" height="228" alt="image" src="https://github.com/user-attachments/assets/1eeb78db-58e5-443d-a426-432608e8b98e" />

host details card:
<img width="437" height="787" alt="image" src="https://github.com/user-attachments/assets/eb2f0f44-b9ee-49d5-bb9f-8c9eb93f9926" />

host details tab:
<img width="1640" height="705" alt="image" src="https://github.com/user-attachments/assets/0db08c4f-affe-4eab-8e5a-0b92863133e3" />

cve modal view:
<img width="1385" height="700" alt="image" src="https://github.com/user-attachments/assets/e621a4f7-2cd5-4d61-b106-d1d3be0ce811" />

host overview:
<img width="374" height="173" alt="image" src="https://github.com/user-attachments/assets/8b36ad39-d137-4e63-a32f-62798a635d29" />

api:
<img width="606" height="871" alt="image" src="https://github.com/user-attachments/assets/91731193-219b-4ac4-8e32-45062e406440" />




